### PR TITLE
P2P Multiplayer

### DIFF
--- a/Assets/Prefabs/Players/Thief.prefab
+++ b/Assets/Prefabs/Players/Thief.prefab
@@ -72,7 +72,7 @@ Camera:
   m_Depth: 0
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 55
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0

--- a/Assets/Prefabs/Rooms/Trap.prefab
+++ b/Assets/Prefabs/Rooms/Trap.prefab
@@ -13,8 +13,8 @@ GameObject:
   - component: {fileID: 770983624696767338}
   - component: {fileID: 4174426712248385772}
   - component: {fileID: -6455643877599139894}
-  - component: {fileID: -1294195979064003457}
-  m_Layer: 6
+  - component: {fileID: 8005452678695168047}
+  m_Layer: 3
   m_Name: Trap
   m_TagString: Trap
   m_Icon: {fileID: 0}
@@ -134,7 +134,7 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
---- !u!114 &-1294195979064003457
+--- !u!114 &8005452678695168047
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -123,6 +123,140 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &89650977
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 89650978}
+  - component: {fileID: 89650980}
+  - component: {fileID: 89650979}
+  m_Layer: 5
+  m_Name: RoomCode
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &89650978
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 89650977}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1336677134}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -18, y: -12}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 1, y: 1}
+--- !u!114 &89650979
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 89650977}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'Room Code: ######'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 4
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: -141.38937, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &89650980
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 89650977}
+  m_CullTransparentMesh: 1
 --- !u!1 &89986774
 GameObject:
   m_ObjectHideFlags: 0
@@ -904,6 +1038,58 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 321813910}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &330709451
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 330709452}
+  - component: {fileID: 330709453}
+  m_Layer: 5
+  m_Name: Text Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &330709452
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 330709451}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2056115471}
+  - {fileID: 1555782234}
+  m_Father: {fileID: 2101824720}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -0.5}
+  m_SizeDelta: {x: -20, y: -13}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &330709453
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 330709451}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3312d7739989d2b4e91e6319e9a96d76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding: {x: -8, y: -5, z: -8, w: -5}
+  m_Softness: {x: 0, y: 0}
 --- !u!1 &351443054
 GameObject:
   m_ObjectHideFlags: 0
@@ -1221,6 +1407,140 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 399827954}
   m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &420006791
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 420006792}
+  - component: {fileID: 420006794}
+  - component: {fileID: 420006793}
+  m_Layer: 5
+  m_Name: PlayerList
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &420006792
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 420006791}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1336677134}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -18, y: -516}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 1, y: 1}
+--- !u!114 &420006793
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 420006791}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Players
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 4
+  m_VerticalAlignment: 1024
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: -141.38937, y: -444.3062, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &420006794
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 420006791}
+  m_CullTransparentMesh: 1
 --- !u!1 &488607868
 GameObject:
   m_ObjectHideFlags: 0
@@ -1317,7 +1637,7 @@ MonoBehaviour:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_SelectedColor: {r: 1, g: 0.5330188, b: 0.5330188, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
@@ -1337,22 +1657,10 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 707800970}
-        m_TargetAssemblyTypeName: SetClientPlayers, Assembly-CSharp
-        m_MethodName: SpawnAsGuard
+      - m_Target: {fileID: 749713766}
+        m_TargetAssemblyTypeName: LobbyManager, Assembly-CSharp
+        m_MethodName: SetPlayerAsGuard
         m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 1336677133}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -1409,7 +1717,7 @@ GameObject:
   m_Component:
   - component: {fileID: 592539523}
   - component: {fileID: 592539525}
-  - component: {fileID: 592539524}
+  - component: {fileID: 592539526}
   m_Layer: 5
   m_Name: HostSelection
   m_TagString: Untagged
@@ -1431,6 +1739,7 @@ RectTransform:
   m_Children:
   - {fileID: 1959902197}
   - {fileID: 2074477514}
+  - {fileID: 2101824720}
   m_Father: {fileID: 678799890}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -1438,36 +1747,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &592539524
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 592539522}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 0.392}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
 --- !u!222 &592539525
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -1476,6 +1755,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 592539522}
   m_CullTransparentMesh: 1
+--- !u!225 &592539526
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 592539522}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
 --- !u!1 &622103582
 GameObject:
   m_ObjectHideFlags: 0
@@ -1917,6 +2208,7 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 927917578}
   - {fileID: 592539523}
   - {fileID: 1336677134}
   m_Father: {fileID: 0}
@@ -1938,6 +2230,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 98069eb0fb4da9f488192c4ba1ca34d7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  PlayerType: 
 --- !u!1 &687968353
 GameObject:
   m_ObjectHideFlags: 0
@@ -2172,7 +2465,7 @@ GameObject:
   - component: {fileID: 707800970}
   - component: {fileID: 707800969}
   m_Layer: 0
-  m_Name: Managers
+  m_Name: NetworkScripts
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -2213,8 +2506,6 @@ MonoBehaviour:
   guardPrefab: {fileID: 6950326788558767763, guid: a60b6599e21938c44bf75e46673cc013, type: 3}
   thiefPrefab: {fileID: 6501310672267175682, guid: 7604196884fb4ff41b12b946132a92fe, type: 3}
   thiefSpawnPoint: {fileID: 1703252198}
-  hostSelection: {fileID: 592539522}
-  playerSelection: {fileID: 1336677133}
 --- !u!4 &707800971
 Transform:
   m_ObjectHideFlags: 0
@@ -2268,6 +2559,58 @@ Transform:
   - {fileID: 963910458}
   m_Father: {fileID: 687968354}
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
+--- !u!1 &749713765
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 749713767}
+  - component: {fileID: 749713766}
+  m_Layer: 0
+  m_Name: Managers
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &749713766
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 749713765}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4111e5a60ac828d48909afd115484439, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  heartBeatTimerMax: 15
+  lobbyUpdateTimerMax: 1.1
+  roomCodeInput: {fileID: 2101824721}
+  hostSelection: {fileID: 592539522}
+  playerSelection: {fileID: 1336677133}
+  background: {fileID: 927917577}
+  roomCodeText: {fileID: 89650979}
+  playerListText: {fileID: 420006793}
+--- !u!4 &749713767
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 749713765}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 435.38928, y: 305.71902, z: 3.600422}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &803928091
 GameObject:
   m_ObjectHideFlags: 0
@@ -2465,6 +2808,81 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1824328567}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &927917577
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 927917578}
+  - component: {fileID: 927917580}
+  - component: {fileID: 927917579}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &927917578
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 927917577}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 13.5, y: 7.5, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 678799890}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -1232, y: -474}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &927917579
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 927917577}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.3962264, g: 0.3962264, b: 0.3962264, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &927917580
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 927917577}
+  m_CullTransparentMesh: 1
 --- !u!1 &932493138
 GameObject:
   m_ObjectHideFlags: 0
@@ -3130,7 +3548,7 @@ MonoBehaviour:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_SelectedColor: {r: 1, g: 0.53333336, b: 0.53333336, a: 1}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
@@ -3150,22 +3568,10 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 707800970}
-        m_TargetAssemblyTypeName: SetClientPlayers, Assembly-CSharp
-        m_MethodName: SpawnAsThief
+      - m_Target: {fileID: 749713766}
+        m_TargetAssemblyTypeName: LobbyManager, Assembly-CSharp
+        m_MethodName: SetPlayerAsThief
         m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 1336677133}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -3774,7 +4180,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1336677134}
   - component: {fileID: 1336677136}
-  - component: {fileID: 1336677135}
+  - component: {fileID: 1336677137}
   m_Layer: 5
   m_Name: PlayerSelection
   m_TagString: Untagged
@@ -3796,6 +4202,9 @@ RectTransform:
   m_Children:
   - {fileID: 512150083}
   - {fileID: 1085637775}
+  - {fileID: 1343687577}
+  - {fileID: 89650978}
+  - {fileID: 420006792}
   m_Father: {fileID: 678799890}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -3803,27 +4212,142 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1336677135
-MonoBehaviour:
+--- !u!222 &1336677136
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1336677133}
+  m_CullTransparentMesh: 1
+--- !u!225 &1336677137
+CanvasGroup:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1336677133}
   m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
+--- !u!1 &1343687576
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1343687577}
+  - component: {fileID: 1343687580}
+  - component: {fileID: 1343687579}
+  - component: {fileID: 1343687578}
+  m_Layer: 5
+  m_Name: StartButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1343687577
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1343687576}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.9706199, y: 1.9706199, z: 1.9706199}
+  m_ConstrainProportionsScale: 1
+  m_Children:
+  - {fileID: 1931367477}
+  m_Father: {fileID: 1336677134}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 20, y: -478}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0, y: 1}
+--- !u!114 &1343687578
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1343687576}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1343687579}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 749713766}
+        m_TargetAssemblyTypeName: LobbyManager, Assembly-CSharp
+        m_MethodName: StartGame
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1343687579
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1343687576}
+  m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 0.392}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -3833,13 +4357,13 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!222 &1336677136
+--- !u!222 &1343687580
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1336677133}
+  m_GameObject: {fileID: 1343687576}
   m_CullTransparentMesh: 1
 --- !u!1 &1361648621
 GameObject:
@@ -4368,6 +4892,140 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1543936287}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1555782233
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1555782234}
+  - component: {fileID: 1555782236}
+  - component: {fileID: 1555782235}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1555782234
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1555782233}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 330709452}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1555782235
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1555782233}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\u200B"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 1
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1555782236
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1555782233}
+  m_CullTransparentMesh: 1
 --- !u!1 &1581479744
 GameObject:
   m_ObjectHideFlags: 0
@@ -4971,6 +5629,140 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1931367476
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1931367477}
+  - component: {fileID: 1931367479}
+  - component: {fileID: 1931367478}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1931367477
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1931367476}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1343687577}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1931367478
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1931367476}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Start
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1931367479
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1931367476}
+  m_CullTransparentMesh: 1
 --- !u!1 &1959902196
 GameObject:
   m_ObjectHideFlags: 0
@@ -5054,22 +5846,10 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 678799891}
-        m_TargetAssemblyTypeName: StartNetwork, Assembly-CSharp
-        m_MethodName: StartHost
+      - m_Target: {fileID: 749713766}
+        m_TargetAssemblyTypeName: LobbyManager, Assembly-CSharp
+        m_MethodName: CreateLobby
         m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 592539522}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -5221,6 +6001,161 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1999601106}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &2056115470
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2056115471}
+  - component: {fileID: 2056115474}
+  - component: {fileID: 2056115473}
+  - component: {fileID: 2056115472}
+  m_Layer: 5
+  m_Name: Placeholder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2056115471
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2056115470}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 330709452}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2056115472
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2056115470}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 1
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!114 &2056115473
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2056115470}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Enter code...
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 2150773298
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 0.5}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 2
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 1
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &2056115474
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2056115470}
+  m_CullTransparentMesh: 1
 --- !u!1 &2074477513
 GameObject:
   m_ObjectHideFlags: 0
@@ -5304,22 +6239,10 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 678799891}
-        m_TargetAssemblyTypeName: StartNetwork, Assembly-CSharp
-        m_MethodName: StartClient
-        m_Mode: 5
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 592539522}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
+      - m_Target: {fileID: 749713766}
+        m_TargetAssemblyTypeName: LobbyManager, Assembly-CSharp
+        m_MethodName: JoinLobby
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -5366,6 +6289,181 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2074477513}
   m_CullTransparentMesh: 1
+--- !u!1 &2101824719
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2101824720}
+  - component: {fileID: 2101824723}
+  - component: {fileID: 2101824722}
+  - component: {fileID: 2101824721}
+  m_Layer: 5
+  m_Name: RoomCodeField
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2101824720
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2101824719}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.6364, y: 1.6364, z: 1.6364}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 330709452}
+  m_Father: {fileID: 592539523}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -197, y: 175}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2101824721
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2101824719}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2da0c512f12947e489f739169773d7ca, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2101824722}
+  m_TextViewport: {fileID: 330709452}
+  m_TextComponent: {fileID: 1555782235}
+  m_Placeholder: {fileID: 2056115473}
+  m_VerticalScrollbar: {fileID: 0}
+  m_VerticalScrollbarEventHandler: {fileID: 0}
+  m_LayoutGroup: {fileID: 0}
+  m_ScrollSensitivity: 1
+  m_ContentType: 0
+  m_InputType: 0
+  m_AsteriskChar: 42
+  m_KeyboardType: 0
+  m_LineType: 0
+  m_HideMobileInput: 0
+  m_HideSoftKeyboard: 0
+  m_CharacterValidation: 0
+  m_RegexValue: 
+  m_GlobalPointSize: 14
+  m_CharacterLimit: 0
+  m_OnEndEdit:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnSubmit:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnSelect:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnDeselect:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnTextSelection:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnEndTextSelection:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_OnTouchScreenKeyboardStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_CaretColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_CustomCaretColor: 0
+  m_SelectionColor: {r: 0.65882355, g: 0.80784315, b: 1, a: 0.7529412}
+  m_Text: 
+  m_CaretBlinkRate: 0.85
+  m_CaretWidth: 1
+  m_ReadOnly: 0
+  m_RichText: 1
+  m_GlobalFontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_OnFocusSelectAll: 1
+  m_ResetOnDeActivation: 1
+  m_RestoreOriginalTextOnEscape: 1
+  m_isRichTextEditingAllowed: 0
+  m_LineLimit: 0
+  m_InputValidator: {fileID: 0}
+--- !u!114 &2101824722
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2101824719}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10911, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &2101824723
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2101824719}
+  m_CullTransparentMesh: 1
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -5378,3 +6476,4 @@ SceneRoots:
   - {fileID: 678799890}
   - {fileID: 1910717883}
   - {fileID: 707800971}
+  - {fileID: 749713767}

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -561,7 +561,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6960e84d07fb87f47956e7a81d71c4e6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_ProtocolType: 0
+  m_ProtocolType: 1
   m_MaxPacketQueueSize: 128
   m_MaxPayloadSize: 6144
   m_HeartbeatTimeoutMS: 500
@@ -5307,7 +5307,7 @@ MonoBehaviour:
       - m_Target: {fileID: 678799891}
         m_TargetAssemblyTypeName: StartNetwork, Assembly-CSharp
         m_MethodName: StartClient
-        m_Mode: 1
+        m_Mode: 5
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -3206,9 +3206,425 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 687968354}
     m_Modifications:
+    - target: {fileID: 10295049984164746, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2317929524
+      objectReference: {fileID: 0}
+    - target: {fileID: 59103223160112793, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1580317652
+      objectReference: {fileID: 0}
+    - target: {fileID: 121908274594344866, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1929449099
+      objectReference: {fileID: 0}
+    - target: {fileID: 148355908056294398, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3920312291
+      objectReference: {fileID: 0}
+    - target: {fileID: 157054354457328400, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1274610490
+      objectReference: {fileID: 0}
+    - target: {fileID: 266468857538330318, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 4003887532
+      objectReference: {fileID: 0}
+    - target: {fileID: 266672442151927380, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1580349308
+      objectReference: {fileID: 0}
+    - target: {fileID: 291775516480284683, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 346954467
+      objectReference: {fileID: 0}
+    - target: {fileID: 291961459496839313, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2844378278
+      objectReference: {fileID: 0}
+    - target: {fileID: 369872207637414727, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 477311513
+      objectReference: {fileID: 0}
+    - target: {fileID: 401393759934491983, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 4088031761
+      objectReference: {fileID: 0}
+    - target: {fileID: 579596211900621527, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1504028823
+      objectReference: {fileID: 0}
+    - target: {fileID: 666311701603366778, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1293659236
+      objectReference: {fileID: 0}
+    - target: {fileID: 735587422970639951, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1029056247
+      objectReference: {fileID: 0}
+    - target: {fileID: 771870230638862026, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2383135584
+      objectReference: {fileID: 0}
+    - target: {fileID: 772268007158153524, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2800531950
+      objectReference: {fileID: 0}
+    - target: {fileID: 828730727444787328, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 873637365
+      objectReference: {fileID: 0}
+    - target: {fileID: 882652001939449567, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 979760687
+      objectReference: {fileID: 0}
+    - target: {fileID: 939093758432040811, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1309714487
+      objectReference: {fileID: 0}
+    - target: {fileID: 939306035859007827, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2522589354
+      objectReference: {fileID: 0}
+    - target: {fileID: 939504680764098709, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 837084946
+      objectReference: {fileID: 0}
+    - target: {fileID: 975774479832031248, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3153050918
+      objectReference: {fileID: 0}
+    - target: {fileID: 1131761171524809864, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3091465063
+      objectReference: {fileID: 0}
+    - target: {fileID: 1141263362366669848, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3462751317
+      objectReference: {fileID: 0}
+    - target: {fileID: 1180935145811509529, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3644510009
+      objectReference: {fileID: 0}
+    - target: {fileID: 1220874753614804991, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3726819651
+      objectReference: {fileID: 0}
+    - target: {fileID: 1310408842940469912, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 4005979446
+      objectReference: {fileID: 0}
+    - target: {fileID: 1358654132716902283, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 492750140
+      objectReference: {fileID: 0}
+    - target: {fileID: 1391437570655992739, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1739357789
+      objectReference: {fileID: 0}
+    - target: {fileID: 1508864738396368380, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3870303818
+      objectReference: {fileID: 0}
+    - target: {fileID: 1541666867999556052, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 322250109
+      objectReference: {fileID: 0}
+    - target: {fileID: 1553865580691326151, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 237831068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1653634420151942154, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2804728324
+      objectReference: {fileID: 0}
+    - target: {fileID: 1653729885524114576, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 236654661
+      objectReference: {fileID: 0}
+    - target: {fileID: 1679449566817853856, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 520899721
+      objectReference: {fileID: 0}
+    - target: {fileID: 1687849890400532814, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2689579003
+      objectReference: {fileID: 0}
+    - target: {fileID: 1719380167286183750, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1699611165
+      objectReference: {fileID: 0}
+    - target: {fileID: 1749718917285726923, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1101469566
+      objectReference: {fileID: 0}
+    - target: {fileID: 1749823616257338125, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3910578054
+      objectReference: {fileID: 0}
+    - target: {fileID: 1916033603013346886, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1223771618
+      objectReference: {fileID: 0}
+    - target: {fileID: 1942555950184068822, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2021823684
+      objectReference: {fileID: 0}
+    - target: {fileID: 1999964378362045307, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3666738745
+      objectReference: {fileID: 0}
+    - target: {fileID: 2053285619615610148, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 234582773
+      objectReference: {fileID: 0}
+    - target: {fileID: 2101192061414658073, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2629506699
+      objectReference: {fileID: 0}
+    - target: {fileID: 2216251119377986270, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1327954971
+      objectReference: {fileID: 0}
+    - target: {fileID: 2266680943747200017, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2408050491
+      objectReference: {fileID: 0}
+    - target: {fileID: 2303080190405084010, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1811687361
+      objectReference: {fileID: 0}
+    - target: {fileID: 2303430868853914962, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3650577225
+      objectReference: {fileID: 0}
+    - target: {fileID: 2382855769795876354, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1425432612
+      objectReference: {fileID: 0}
+    - target: {fileID: 2422626005584303901, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 875203427
+      objectReference: {fileID: 0}
+    - target: {fileID: 2747500204849004866, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 455493005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2787283792858120285, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2878155810
+      objectReference: {fileID: 0}
+    - target: {fileID: 2824210943522276260, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 47391083
+      objectReference: {fileID: 0}
+    - target: {fileID: 2900005162351839027, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 207118617
+      objectReference: {fileID: 0}
+    - target: {fileID: 2907600267970098566, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 241827093
+      objectReference: {fileID: 0}
+    - target: {fileID: 2948887948580022399, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3232037778
+      objectReference: {fileID: 0}
+    - target: {fileID: 3122895104271930759, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2749915324
+      objectReference: {fileID: 0}
+    - target: {fileID: 3135844623930341756, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2526333200
+      objectReference: {fileID: 0}
+    - target: {fileID: 3187197748092923683, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3315994137
+      objectReference: {fileID: 0}
+    - target: {fileID: 3236172680361149400, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2996163165
+      objectReference: {fileID: 0}
+    - target: {fileID: 3336386207427166983, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1272449752
+      objectReference: {fileID: 0}
+    - target: {fileID: 3410206310256721440, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1031153462
+      objectReference: {fileID: 0}
+    - target: {fileID: 3451497209929884633, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 329655916
+      objectReference: {fileID: 0}
+    - target: {fileID: 3634429578089366010, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 399706214
+      objectReference: {fileID: 0}
+    - target: {fileID: 3742457504955171331, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3010109557
+      objectReference: {fileID: 0}
+    - target: {fileID: 3809885950161704259, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 490504333
+      objectReference: {fileID: 0}
     - target: {fileID: 3868360972269367235, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
       propertyPath: m_Name
       value: TileRoom
+      objectReference: {fileID: 0}
+    - target: {fileID: 3877571881286490021, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3614231594
+      objectReference: {fileID: 0}
+    - target: {fileID: 4154776789255324038, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1413412791
+      objectReference: {fileID: 0}
+    - target: {fileID: 4233551478405632818, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3097449553
+      objectReference: {fileID: 0}
+    - target: {fileID: 4254972586702635353, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1812035522
+      objectReference: {fileID: 0}
+    - target: {fileID: 4373912656130660102, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2964867955
+      objectReference: {fileID: 0}
+    - target: {fileID: 4402362763476350936, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3361315828
+      objectReference: {fileID: 0}
+    - target: {fileID: 4431376860644754797, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3304556307
+      objectReference: {fileID: 0}
+    - target: {fileID: 4444216537956543009, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3822229047
+      objectReference: {fileID: 0}
+    - target: {fileID: 4523101115364260642, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3405996959
+      objectReference: {fileID: 0}
+    - target: {fileID: 4653276994458547170, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 678649715
+      objectReference: {fileID: 0}
+    - target: {fileID: 4667377700810368276, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 18198783
+      objectReference: {fileID: 0}
+    - target: {fileID: 4724593816630564150, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 29641837
+      objectReference: {fileID: 0}
+    - target: {fileID: 4779597111719761152, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1730658122
+      objectReference: {fileID: 0}
+    - target: {fileID: 4782790774665946594, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1454095230
+      objectReference: {fileID: 0}
+    - target: {fileID: 5038256238809662303, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2363718560
+      objectReference: {fileID: 0}
+    - target: {fileID: 5128530840843560381, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2369008772
+      objectReference: {fileID: 0}
+    - target: {fileID: 5150475506634650443, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1179218704
+      objectReference: {fileID: 0}
+    - target: {fileID: 5207653492478614682, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 158638089
+      objectReference: {fileID: 0}
+    - target: {fileID: 5212878482076629355, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1274699980
+      objectReference: {fileID: 0}
+    - target: {fileID: 5234531042362512076, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3609571539
+      objectReference: {fileID: 0}
+    - target: {fileID: 5251029261126362977, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2085180728
+      objectReference: {fileID: 0}
+    - target: {fileID: 5261561362416787630, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 4059526950
+      objectReference: {fileID: 0}
+    - target: {fileID: 5287706425905677148, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 35563390
+      objectReference: {fileID: 0}
+    - target: {fileID: 5410214283522485065, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 389712375
+      objectReference: {fileID: 0}
+    - target: {fileID: 5524509766865747222, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1418822810
+      objectReference: {fileID: 0}
+    - target: {fileID: 5569166186132466714, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 82792455
+      objectReference: {fileID: 0}
+    - target: {fileID: 5700215014421070995, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2183473251
+      objectReference: {fileID: 0}
+    - target: {fileID: 5719736658097680702, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1469911392
+      objectReference: {fileID: 0}
+    - target: {fileID: 5757900748282867508, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3080608653
+      objectReference: {fileID: 0}
+    - target: {fileID: 5763125551022590661, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2172798216
+      objectReference: {fileID: 0}
+    - target: {fileID: 5810093398384701923, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3083001378
+      objectReference: {fileID: 0}
+    - target: {fileID: 6012124067823403319, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3290177086
+      objectReference: {fileID: 0}
+    - target: {fileID: 6111573369639901032, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 685452517
+      objectReference: {fileID: 0}
+    - target: {fileID: 6162140180204201802, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 153360512
+      objectReference: {fileID: 0}
+    - target: {fileID: 6184084779121045948, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1623228918
+      objectReference: {fileID: 0}
+    - target: {fileID: 6274922402561398622, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1856181274
+      objectReference: {fileID: 0}
+    - target: {fileID: 6277569609291835324, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 447709619
+      objectReference: {fileID: 0}
+    - target: {fileID: 6343370315729530436, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2087642034
       objectReference: {fileID: 0}
     - target: {fileID: 6396444353274284996, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
       propertyPath: m_LocalPosition.x
@@ -3249,6 +3665,250 @@ PrefabInstance:
     - target: {fileID: 6396444353274284996, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6479143634857852744, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2626543754
+      objectReference: {fileID: 0}
+    - target: {fileID: 6532935989474700650, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1533974517
+      objectReference: {fileID: 0}
+    - target: {fileID: 6602223236658616157, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2516713487
+      objectReference: {fileID: 0}
+    - target: {fileID: 6627796553361831087, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 996924817
+      objectReference: {fileID: 0}
+    - target: {fileID: 6638374469976097026, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1668114380
+      objectReference: {fileID: 0}
+    - target: {fileID: 6648817991819453168, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1304613915
+      objectReference: {fileID: 0}
+    - target: {fileID: 6702701844366925508, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 79809435
+      objectReference: {fileID: 0}
+    - target: {fileID: 6746090806077318463, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3700453563
+      objectReference: {fileID: 0}
+    - target: {fileID: 6765885130752905362, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3166661919
+      objectReference: {fileID: 0}
+    - target: {fileID: 6897224160116717595, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 335113332
+      objectReference: {fileID: 0}
+    - target: {fileID: 6930070764356505682, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3266939623
+      objectReference: {fileID: 0}
+    - target: {fileID: 7019985931594081087, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2757285752
+      objectReference: {fileID: 0}
+    - target: {fileID: 7020672527713590759, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2540428255
+      objectReference: {fileID: 0}
+    - target: {fileID: 7138774584072883888, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1399721920
+      objectReference: {fileID: 0}
+    - target: {fileID: 7170139434059137192, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 4121052101
+      objectReference: {fileID: 0}
+    - target: {fileID: 7223354572980541175, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1685794451
+      objectReference: {fileID: 0}
+    - target: {fileID: 7254723733308250351, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3406722258
+      objectReference: {fileID: 0}
+    - target: {fileID: 7382557655176174022, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 379981484
+      objectReference: {fileID: 0}
+    - target: {fileID: 7408844778837183416, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 780904238
+      objectReference: {fileID: 0}
+    - target: {fileID: 7409531240678225248, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 332067873
+      objectReference: {fileID: 0}
+    - target: {fileID: 7463449477440161293, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 258411459
+      objectReference: {fileID: 0}
+    - target: {fileID: 7526114772312137495, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1066375727
+      objectReference: {fileID: 0}
+    - target: {fileID: 7603335948861089575, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1120393242
+      objectReference: {fileID: 0}
+    - target: {fileID: 7626010202728374637, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3411475024
+      objectReference: {fileID: 0}
+    - target: {fileID: 7628113861330403997, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 4175722523
+      objectReference: {fileID: 0}
+    - target: {fileID: 7702475178151525487, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 628919552
+      objectReference: {fileID: 0}
+    - target: {fileID: 7722486111919386739, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1563621712
+      objectReference: {fileID: 0}
+    - target: {fileID: 7807161239406110754, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 4276541643
+      objectReference: {fileID: 0}
+    - target: {fileID: 7879963683413256752, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 27777357
+      objectReference: {fileID: 0}
+    - target: {fileID: 7913112132494132607, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 4059887006
+      objectReference: {fileID: 0}
+    - target: {fileID: 7943092622799532408, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2315979286
+      objectReference: {fileID: 0}
+    - target: {fileID: 7956442743181309746, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1192303860
+      objectReference: {fileID: 0}
+    - target: {fileID: 7984249119239303749, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1624183759
+      objectReference: {fileID: 0}
+    - target: {fileID: 7990465539071456116, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2246696648
+      objectReference: {fileID: 0}
+    - target: {fileID: 7992747998987471285, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 4119680056
+      objectReference: {fileID: 0}
+    - target: {fileID: 8056325001983510856, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 497394881
+      objectReference: {fileID: 0}
+    - target: {fileID: 8209075164780239537, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 554026944
+      objectReference: {fileID: 0}
+    - target: {fileID: 8273945204508017747, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2483447416
+      objectReference: {fileID: 0}
+    - target: {fileID: 8301708066735774616, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3042850798
+      objectReference: {fileID: 0}
+    - target: {fileID: 8327168358189566438, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2486286592
+      objectReference: {fileID: 0}
+    - target: {fileID: 8371499637000741217, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3000770449
+      objectReference: {fileID: 0}
+    - target: {fileID: 8397637591316860359, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 4286427158
+      objectReference: {fileID: 0}
+    - target: {fileID: 8557113352613495542, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2056409381
+      objectReference: {fileID: 0}
+    - target: {fileID: 8687601036677842721, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 183873790
+      objectReference: {fileID: 0}
+    - target: {fileID: 8726024832504162940, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2569060970
+      objectReference: {fileID: 0}
+    - target: {fileID: 8779120699527849074, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 311076594
+      objectReference: {fileID: 0}
+    - target: {fileID: 8830532430106020630, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3127688094
+      objectReference: {fileID: 0}
+    - target: {fileID: 8872930000397948572, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3007668610
+      objectReference: {fileID: 0}
+    - target: {fileID: 8875323929549632876, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2146239887
+      objectReference: {fileID: 0}
+    - target: {fileID: 8902572853738729499, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 223743148
+      objectReference: {fileID: 0}
+    - target: {fileID: 8908784720905548074, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 477155392
+      objectReference: {fileID: 0}
+    - target: {fileID: 8911070495462837227, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 30520548
+      objectReference: {fileID: 0}
+    - target: {fileID: 8941204376654552500, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3819589533
+      objectReference: {fileID: 0}
+    - target: {fileID: 8943495636942055285, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 4108180723
+      objectReference: {fileID: 0}
+    - target: {fileID: 8949703260412749380, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3825409146
+      objectReference: {fileID: 0}
+    - target: {fileID: 8979346108401516739, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 2000713295
+      objectReference: {fileID: 0}
+    - target: {fileID: 8990859759586944377, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3330369500
+      objectReference: {fileID: 0}
+    - target: {fileID: 9109166478041395757, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3704231931
+      objectReference: {fileID: 0}
+    - target: {fileID: 9126228257686600739, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 188559186
+      objectReference: {fileID: 0}
+    - target: {fileID: 9164682821545021822, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1237139602
+      objectReference: {fileID: 0}
+    - target: {fileID: 9197822475858492977, guid: af6e732255b67f04a8ad2ab892f0488e, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 4275423379
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -1254,6 +1254,228 @@ Transform:
   - {fileID: 1581479745}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &512150082
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 512150083}
+  - component: {fileID: 512150086}
+  - component: {fileID: 512150085}
+  - component: {fileID: 512150084}
+  m_Layer: 5
+  m_Name: GuardButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &512150083
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 512150082}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.9706199, y: 1.9706199, z: 1.9706199}
+  m_ConstrainProportionsScale: 1
+  m_Children:
+  - {fileID: 1195629296}
+  m_Father: {fileID: 1336677134}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 20, y: -19}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0, y: 1}
+--- !u!114 &512150084
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 512150082}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 512150085}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 707800970}
+        m_TargetAssemblyTypeName: SetClientPlayers, Assembly-CSharp
+        m_MethodName: SpawnAsGuard
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 1336677133}
+        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
+        m_MethodName: SetActive
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &512150085
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 512150082}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &512150086
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 512150082}
+  m_CullTransparentMesh: 1
+--- !u!1 &592539522
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 592539523}
+  - component: {fileID: 592539525}
+  - component: {fileID: 592539524}
+  m_Layer: 5
+  m_Name: HostSelection
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &592539523
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 592539522}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1959902197}
+  - {fileID: 2074477514}
+  m_Father: {fileID: 678799890}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &592539524
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 592539522}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.392}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &592539525
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 592539522}
+  m_CullTransparentMesh: 1
 --- !u!1 &622103582
 GameObject:
   m_ObjectHideFlags: 0
@@ -1695,8 +1917,8 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1959902197}
-  - {fileID: 2074477514}
+  - {fileID: 592539523}
+  - {fileID: 1336677134}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -1745,6 +1967,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 1703252198}
   - {fileID: 1006635476}
   - {fileID: 726144806}
   - {fileID: 1114502667}
@@ -1989,6 +2212,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   guardPrefab: {fileID: 6950326788558767763, guid: a60b6599e21938c44bf75e46673cc013, type: 3}
   thiefPrefab: {fileID: 6501310672267175682, guid: 7604196884fb4ff41b12b946132a92fe, type: 3}
+  thiefSpawnPoint: {fileID: 1703252198}
+  hostSelection: {fileID: 592539522}
+  playerSelection: {fileID: 1336677133}
 --- !u!4 &707800971
 Transform:
   m_ObjectHideFlags: 0
@@ -2841,6 +3067,151 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   source: {fileID: 803928093}
+--- !u!1 &1085637774
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1085637775}
+  - component: {fileID: 1085637778}
+  - component: {fileID: 1085637777}
+  - component: {fileID: 1085637776}
+  m_Layer: 5
+  m_Name: ThiefButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1085637775
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1085637774}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.9706199, y: 1.9706199, z: 1.9706199}
+  m_ConstrainProportionsScale: 1
+  m_Children:
+  - {fileID: 1198702895}
+  m_Father: {fileID: 1336677134}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 20, y: -80.72104}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0, y: 1}
+--- !u!114 &1085637776
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1085637774}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1085637777}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 707800970}
+        m_TargetAssemblyTypeName: SetClientPlayers, Assembly-CSharp
+        m_MethodName: SpawnAsThief
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 1336677133}
+        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
+        m_MethodName: SetActive
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1085637777
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1085637774}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1085637778
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1085637774}
+  m_CullTransparentMesh: 1
 --- !u!1 &1114502666
 GameObject:
   m_ObjectHideFlags: 0
@@ -2985,6 +3356,274 @@ Transform:
   m_Children: []
   m_Father: {fileID: 164141640}
   m_LocalEulerAnglesHint: {x: 90, y: -90, z: 90}
+--- !u!1 &1195629295
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1195629296}
+  - component: {fileID: 1195629298}
+  - component: {fileID: 1195629297}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1195629296
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1195629295}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 512150083}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1195629297
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1195629295}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Guard
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1195629298
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1195629295}
+  m_CullTransparentMesh: 1
+--- !u!1 &1198702894
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1198702895}
+  - component: {fileID: 1198702897}
+  - component: {fileID: 1198702896}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1198702895
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1198702894}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1085637775}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1198702896
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1198702894}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Thief
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1198702897
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1198702894}
+  m_CullTransparentMesh: 1
 --- !u!1 &1216116066
 GameObject:
   m_ObjectHideFlags: 0
@@ -3125,6 +3764,83 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1325025540}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1336677133
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1336677134}
+  - component: {fileID: 1336677136}
+  - component: {fileID: 1336677135}
+  m_Layer: 5
+  m_Name: PlayerSelection
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &1336677134
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1336677133}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 512150083}
+  - {fileID: 1085637775}
+  m_Father: {fileID: 678799890}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1336677135
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1336677133}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.392}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1336677136
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1336677133}
+  m_CullTransparentMesh: 1
 --- !u!1 &1361648621
 GameObject:
   m_ObjectHideFlags: 0
@@ -3686,6 +4402,37 @@ Transform:
   - {fileID: 1781313587}
   - {fileID: 634252968}
   m_Father: {fileID: 488607869}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1703252197
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1703252198}
+  m_Layer: 0
+  m_Name: ThiefSpawnPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1703252198
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1703252197}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0.9999999, z: -0, w: 0.0005168616}
+  m_LocalPosition: {x: 3.1862311, y: 3.516, z: -10.77}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 687968354}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1710401056
 GameObject:
@@ -4250,13 +4997,13 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1959902196}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1.9706196, y: 1.9706196, z: 1.9706196}
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 154584390}
-  m_Father: {fileID: 678799890}
+  m_Father: {fileID: 592539523}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -4319,9 +5066,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 678799889}
-        m_TargetAssemblyTypeName: UnityEngine.Behaviour, UnityEngine
-        m_MethodName: set_enabled
+      - m_Target: {fileID: 592539522}
+        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
+        m_MethodName: SetActive
         m_Mode: 6
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4500,13 +5247,13 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2074477513}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1.9706196, y: 1.9706196, z: 1.9706196}
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 622103583}
-  m_Father: {fileID: 678799890}
+  m_Father: {fileID: 592539523}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -4569,9 +5316,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 678799889}
-        m_TargetAssemblyTypeName: UnityEngine.Behaviour, UnityEngine
-        m_MethodName: set_enabled
+      - m_Target: {fileID: 592539522}
+        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
+        m_MethodName: SetActive
         m_Mode: 6
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Assets/Scripts/Networking/LobbyManager.cs
+++ b/Assets/Scripts/Networking/LobbyManager.cs
@@ -1,0 +1,335 @@
+using System.Collections.Generic;
+using TMPro;
+using Unity.Services.Authentication;
+using Unity.Services.Core;
+using Unity.Services.Lobbies;
+using Unity.Services.Lobbies.Models;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class LobbyManager : MonoBehaviour
+{
+    private Lobby hostLobby;
+    private Lobby joinedLobby;
+    private string playerName;
+    private string playerType;
+    private float heartBeatTimer;
+    private float lobbyUpdateTimer;
+    private const string KEY_START_GAME = "StartGame";
+    private const string KEY_PLAYER_THIEF = "Thief";
+    private const string KEY_PLAYER_GUARD = "Guard";
+    [SerializeField] private float heartBeatTimerMax = 15;
+    [SerializeField] private float lobbyUpdateTimerMax = 2f;
+    [SerializeField] private TMP_InputField roomCodeInput;
+    [SerializeField] private GameObject hostSelection;
+    [SerializeField] private GameObject playerSelection;
+    [SerializeField] private GameObject background;
+    [SerializeField] private TextMeshProUGUI roomCodeText;
+    [SerializeField] private TextMeshProUGUI playerListText;
+
+    private async void Start()
+    {
+        await UnityServices.InitializeAsync();
+
+        AuthenticationService.Instance.SignedIn += () =>
+        {
+            Debug.Log("Signed in " + AuthenticationService.Instance.PlayerId);
+        };
+
+        #if UNITY_EDITOR
+            AuthenticationService.Instance.ClearSessionToken();
+        #endif
+
+        await AuthenticationService.Instance.SignInAnonymouslyAsync(); 
+
+        playerName = "Player" + Random.Range(10,99);
+
+        Debug.Log(playerName);
+    }
+
+    private void Update()
+    {
+        HandleLobbyHeartbeat();
+        HandleLobbyPollForUpdates();
+    }
+
+    private void HandleLobbyHeartbeat()
+    {
+        if (hostLobby != null)
+        {
+            heartBeatTimer -= Time.deltaTime;
+            if (heartBeatTimer < 0f)
+            {
+                heartBeatTimer = heartBeatTimerMax;
+
+                LobbyService.Instance.SendHeartbeatPingAsync(hostLobby.Id);
+            }
+        }
+    }
+
+    private async void HandleLobbyPollForUpdates()
+    {
+        if (joinedLobby != null)
+        {
+            lobbyUpdateTimer -= Time.deltaTime;
+            if (lobbyUpdateTimer < 0f)
+            {
+                lobbyUpdateTimer = lobbyUpdateTimerMax;
+
+                Lobby lobby = await LobbyService.Instance.GetLobbyAsync(joinedLobby.Id);
+                joinedLobby = lobby;
+
+                playerListText.text = PrintPlayers();
+            }
+
+            if (joinedLobby.Data[KEY_START_GAME].Value != "0")
+            {
+                if (!IsLobbyHost())
+                {
+                    playerSelection.SetActive(false);
+                    background.SetActive(false);
+                    StartNetwork.Instance.JoinRelay(joinedLobby.Data[KEY_START_GAME].Value, playerType);
+                }
+
+                joinedLobby = null;
+            }
+        }
+    }
+
+    public async void CreateLobby()
+    {
+        try
+        {
+            string lobbyName = "MyLobby";
+            int maxPlayers = 4;
+            CreateLobbyOptions createLobbyOptions = new CreateLobbyOptions()
+            {
+                IsPrivate = false,
+                Player = GetPlayerObject(KEY_PLAYER_GUARD),
+                Data = new Dictionary<string, DataObject>
+                {
+                    { KEY_START_GAME, new DataObject(DataObject.VisibilityOptions.Member, "0") }
+                }
+            };
+
+            Lobby lobby = await LobbyService.Instance.CreateLobbyAsync(lobbyName, maxPlayers, createLobbyOptions);
+
+            hostLobby = lobby;
+            joinedLobby = hostLobby;
+
+            hostSelection.SetActive(false);
+            playerSelection.SetActive(true);
+
+            roomCodeText.text = lobby.LobbyCode;
+            playerListText.text = PrintPlayers();
+
+            Debug.Log($"Created Lobby! {lobby.LobbyCode}");
+        }
+        catch (LobbyServiceException e)
+        {
+            Debug.LogError(e);
+        }
+    }
+
+    public async void ListLobbies()
+    {
+        try
+        {
+            QueryLobbiesOptions queryLobbiesOptions = new QueryLobbiesOptions
+            {
+                Count = 25,
+                Filters = new List<QueryFilter>
+                {
+                    new QueryFilter(QueryFilter.FieldOptions.AvailableSlots, "0", QueryFilter.OpOptions.GT)
+                },
+                Order = new List<QueryOrder>
+                {
+                    new QueryOrder(false, QueryOrder.FieldOptions.Created)
+                }
+            };
+
+            QueryResponse queryResponse = await Lobbies.Instance.QueryLobbiesAsync();
+
+            Debug.Log("Lobbies found: " + queryResponse.Results.Count);
+            foreach (Lobby lobby in queryResponse.Results)
+            {
+                Debug.Log(lobby.Name + " " + lobby.MaxPlayers + " " + lobby.Data["GameMode"].Value);
+            }
+        }
+        catch (LobbyServiceException e)
+        {
+            Debug.LogError(e);
+        }
+    }
+
+    public void JoinLobby()
+    {
+        string lobbyCode = roomCodeInput.text;
+        joinLobbyByCode(lobbyCode);
+    }
+
+    private async void joinLobbyByCode(string lobbyCode)
+    {
+        try
+        {
+            JoinLobbyByCodeOptions joinLobbyByCodeOptions = new JoinLobbyByCodeOptions
+            {
+                Player = GetPlayerObject(KEY_PLAYER_THIEF)
+            };
+
+            Lobby lobby = await Lobbies.Instance.JoinLobbyByCodeAsync(lobbyCode, joinLobbyByCodeOptions);
+            joinedLobby = lobby;
+
+            hostSelection.SetActive(false);
+            playerSelection.SetActive(true);
+
+            roomCodeText.text = lobby.LobbyCode;
+            playerListText.text = PrintPlayers();
+
+            Debug.Log("Joined lobby with code " + lobbyCode);
+        }
+        catch (LobbyServiceException e)
+        {
+            Debug.LogError(e);
+        }
+    }
+
+    private Player GetPlayerObject(string playerType)
+    {
+        return new Player
+        {
+            Data = new Dictionary<string, PlayerDataObject>
+            {
+                { "PlayerName", new PlayerDataObject(PlayerDataObject.VisibilityOptions.Member, playerName) },
+                { "PlayerType", new PlayerDataObject(PlayerDataObject.VisibilityOptions.Member, playerType) }
+            }
+        };
+    }
+
+    public async void QuickJoinLobby()
+    {
+        try
+        {
+            await LobbyService.Instance.QuickJoinLobbyAsync();
+        }
+        catch (LobbyServiceException e)
+        {
+            Debug.LogError(e);
+        }
+    }
+
+    public string PrintPlayers()
+    {
+        return PrintPlayers(joinedLobby);
+    }
+
+    public string PrintPlayers(Lobby lobby)
+    {
+        string sb = "";
+        foreach (Player player in lobby.Players)
+        {
+            sb += $"{player.Data["PlayerName"].Value}\n";
+        }
+        return sb;
+    }
+
+    public void SetPlayerAsGuard()
+    {
+        UpdatePlayerType(KEY_PLAYER_GUARD);
+    }
+
+    public void SetPlayerAsThief()
+    {
+        UpdatePlayerType(KEY_PLAYER_THIEF);
+    }
+
+    public async void UpdatePlayerType(string newPlayerType)
+    {
+        try
+        {
+            playerType = newPlayerType;
+            await LobbyService.Instance.UpdatePlayerAsync(joinedLobby.Id, AuthenticationService.Instance.PlayerId, new UpdatePlayerOptions
+            {
+                Data = new Dictionary<string, PlayerDataObject>
+                {
+                    { "PlayerType", new PlayerDataObject(PlayerDataObject.VisibilityOptions.Member, playerType) }
+                }
+            });
+        }
+        catch (LobbyServiceException e)
+        {
+            Debug.LogError(e);
+        }
+    }
+
+    public async void LeaveLobby()
+    {
+        try
+        {
+            await LobbyService.Instance.RemovePlayerAsync(joinedLobby.Id, AuthenticationService.Instance.PlayerId);
+        }
+        catch (LobbyServiceException e)
+        {
+            Debug.LogError(e);
+        }
+    }
+
+    public async void KickPlayer(string playerId)
+    {
+        try
+        {
+            await LobbyService.Instance.RemovePlayerAsync(joinedLobby.Id, playerId);
+        }
+        catch (LobbyServiceException e)
+        {
+            Debug.LogError(e);
+        }
+    }
+
+    private bool IsLobbyHost()
+    {
+        return AuthenticationService.Instance.PlayerId == joinedLobby.HostId;
+    }
+
+    private Player GetPlayerById(string id)
+    {
+        foreach (Player player in joinedLobby.Players)
+        {
+            if (player.Id == id) return player;
+        }
+
+        return null;
+    }
+
+    public async void StartGame()
+    {
+        if (IsLobbyHost())
+        {
+            try
+            {
+                Debug.Log("StartGame");
+
+                string relayCode = await StartNetwork.Instance.CreateRelay(playerType);
+                
+                Debug.Log("Successfully joined relay");
+
+                Lobby lobby = await Lobbies.Instance.UpdateLobbyAsync(joinedLobby.Id, new UpdateLobbyOptions
+                {
+                    Data = new Dictionary<string, DataObject>
+                    {
+                        { KEY_START_GAME, new DataObject(DataObject.VisibilityOptions.Member, relayCode) }
+                    }
+                });
+
+                playerSelection.SetActive(false);   
+                background.SetActive(false);
+
+                joinedLobby = lobby;
+            }
+            catch (LobbyServiceException e)
+            {
+                Debug.LogError(e);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Networking/LobbyManager.cs.meta
+++ b/Assets/Scripts/Networking/LobbyManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4111e5a60ac828d48909afd115484439
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Networking/SetClientPlayers.cs
+++ b/Assets/Scripts/Networking/SetClientPlayers.cs
@@ -7,39 +7,16 @@ public class SetClientPlayers : NetworkBehaviour
     [SerializeField] private GameObject guardPrefab;
     [SerializeField] private GameObject thiefPrefab;
     [SerializeField] private Transform thiefSpawnPoint;
-    [SerializeField] private GameObject hostSelection;
-    [SerializeField] private GameObject playerSelection;
-
-    private NetworkVariable<bool> guardChosen = new NetworkVariable<bool>(false);
-
     public override void OnNetworkSpawn()
     {
-        if (!guardChosen.Value)
-        {
-            playerSelection.SetActive(true);
-        }
-        else
-        {
-            SpawnAsThief();
-        }
-    }
-
-    public void SpawnAsGuard()
-    {
-        if (guardChosen.Value == true)
-        {
-            SpawnAsThief();
-        }
-        else
+        if (StartNetwork.Instance.PlayerType == "Guard")
         {
             SpawnPlayerServerRpc(NetworkManager.Singleton.LocalClientId, 0);
-            SetGuardChosenServerRpc(true);
         }
-    }
-
-    public void SpawnAsThief()
-    {
-        SpawnPlayerServerRpc(NetworkManager.Singleton.LocalClientId, 1);
+        else
+        {
+            SpawnPlayerServerRpc(NetworkManager.Singleton.LocalClientId, 1);
+        }
     }
 
     [ServerRpc(RequireOwnership = false)]
@@ -54,16 +31,5 @@ public class SetClientPlayers : NetworkBehaviour
         NetworkObject netObj = newPlayer.GetComponent<NetworkObject>();
         newPlayer.SetActive(true);
         netObj.SpawnAsPlayerObject(clientId, true);
-    }
-
-    [ServerRpc(RequireOwnership = false)]
-    public void SetGuardChosenServerRpc(bool chosen)
-    {
-        guardChosen.Value = chosen;
-    }
-
-    public void SpawnThiefLocal()
-    {
-        Instantiate(thiefPrefab, thiefSpawnPoint);
     }
 }

--- a/Assets/Scripts/Networking/SetClientPlayers.cs
+++ b/Assets/Scripts/Networking/SetClientPlayers.cs
@@ -1,17 +1,45 @@
 using Unity.Netcode;
 using UnityEngine;
+using UnityEngine.UI;
 
 public class SetClientPlayers : NetworkBehaviour
 {
     [SerializeField] private GameObject guardPrefab;
     [SerializeField] private GameObject thiefPrefab;
+    [SerializeField] private Transform thiefSpawnPoint;
+    [SerializeField] private GameObject hostSelection;
+    [SerializeField] private GameObject playerSelection;
+
+    private NetworkVariable<bool> guardChosen = new NetworkVariable<bool>(false);
 
     public override void OnNetworkSpawn()
     {
-        if (IsServer)
-            SpawnPlayerServerRpc(NetworkManager.Singleton.LocalClientId, 0);
+        if (!guardChosen.Value)
+        {
+            playerSelection.SetActive(true);
+        }
         else
-            SpawnPlayerServerRpc(NetworkManager.Singleton.LocalClientId, 1);
+        {
+            SpawnAsThief();
+        }
+    }
+
+    public void SpawnAsGuard()
+    {
+        if (guardChosen.Value == true)
+        {
+            SpawnAsThief();
+        }
+        else
+        {
+            SpawnPlayerServerRpc(NetworkManager.Singleton.LocalClientId, 0);
+            SetGuardChosenServerRpc(true);
+        }
+    }
+
+    public void SpawnAsThief()
+    {
+        SpawnPlayerServerRpc(NetworkManager.Singleton.LocalClientId, 1);
     }
 
     [ServerRpc(RequireOwnership = false)]
@@ -21,10 +49,21 @@ public class SetClientPlayers : NetworkBehaviour
         if (prefabId == 0)
             newPlayer = Instantiate(guardPrefab);
         else
-            newPlayer = Instantiate(thiefPrefab);
+            newPlayer = Instantiate(thiefPrefab, thiefSpawnPoint);
 
         NetworkObject netObj = newPlayer.GetComponent<NetworkObject>();
         newPlayer.SetActive(true);
         netObj.SpawnAsPlayerObject(clientId, true);
+    }
+
+    [ServerRpc(RequireOwnership = false)]
+    public void SetGuardChosenServerRpc(bool chosen)
+    {
+        guardChosen.Value = chosen;
+    }
+
+    public void SpawnThiefLocal()
+    {
+        Instantiate(thiefPrefab, thiefSpawnPoint);
     }
 }

--- a/Assets/Scripts/Networking/StartNetwork.cs
+++ b/Assets/Scripts/Networking/StartNetwork.cs
@@ -12,9 +12,4 @@ public class StartNetwork : MonoBehaviour
     {
         NetworkManager.Singleton.StartClient();
     }
-
-    public void StartLocal()
-    {
-        
-    }
 }

--- a/Assets/Scripts/Networking/StartNetwork.cs
+++ b/Assets/Scripts/Networking/StartNetwork.cs
@@ -1,15 +1,63 @@
 using Unity.Netcode;
+using Unity.Netcode.Transports.UTP;
+using Unity.Networking.Transport.Relay;
+using Unity.Services.Authentication;
+using Unity.Services.Core;
+using Unity.Services.Relay;
+using Unity.Services.Relay.Models;
 using UnityEngine;
 
 public class StartNetwork : MonoBehaviour
 {
-    public void StartHost()
+    private async void Start()
     {
-        NetworkManager.Singleton.StartHost();
+        await UnityServices.InitializeAsync();
+
+        AuthenticationService.Instance.SignedIn += () =>
+        {
+            Debug.Log("Signed in " + AuthenticationService.Instance.PlayerId);
+        };
+        await AuthenticationService.Instance.SignInAnonymouslyAsync();      
     }
 
-    public void StartClient()
+    public async void StartHost()
     {
-        NetworkManager.Singleton.StartClient();
+        try 
+        {
+            Allocation allocation = await RelayService.Instance.CreateAllocationAsync(3);
+
+            string joinCode = await RelayService.Instance.GetJoinCodeAsync(allocation.AllocationId);
+
+            Debug.Log(joinCode);
+
+            RelayServerData relayServerData = new RelayServerData(allocation, "dtls");
+
+            NetworkManager.Singleton.GetComponent<UnityTransport>().SetRelayServerData(relayServerData);
+
+            NetworkManager.Singleton.StartHost();
+        }
+        catch (RelayServiceException e)
+        {
+            Debug.LogError(e);
+        }
+    }
+
+    public async void StartClient(string joinCode)
+    {
+        try
+        {
+            Debug.Log("Joining Relay with " + joinCode);
+            JoinAllocation joinAllocation = await RelayService.Instance.JoinAllocationAsync(joinCode);
+
+            RelayServerData relayServerData = new RelayServerData(joinAllocation, "dtls");
+            
+            NetworkManager.Singleton.GetComponent<UnityTransport>().SetRelayServerData(relayServerData);
+
+            NetworkManager.Singleton.StartClient();
+        }
+        catch (RelayServiceException e)
+        {
+            Debug.LogError(e);
+        }
     }
 }

--- a/Assets/Scripts/Rooms/TileTrap.cs
+++ b/Assets/Scripts/Rooms/TileTrap.cs
@@ -1,24 +1,7 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class TileTrap : MonoBehaviour
 {
-
-
-    // Start is called before the first frame update
-    void Start()
-    {
-        
-    }
-
-    // Update is called once per frame
-    void Update()
-    {
-        
-    }
-
-
     void OnTriggerEnter(Collider other)
     {
         if (other.gameObject.CompareTag("Player"))

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -5,6 +5,7 @@
     "com.unity.ide.visualstudio": "2.0.22",
     "com.unity.multiplayer.samples.coop": "https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop.git?path=/Packages/com.unity.multiplayer.samples.coop#main",
     "com.unity.netcode.gameobjects": "1.6.0",
+    "com.unity.services.lobby": "1.1.0",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.7.5",
     "com.unity.ugui": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -140,7 +140,7 @@
     },
     "com.unity.nuget.newtonsoft-json": {
       "version": "3.2.1",
-      "depth": 2,
+      "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
@@ -161,7 +161,7 @@
     },
     "com.unity.services.authentication": {
       "version": "2.7.2",
-      "depth": 2,
+      "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.unity.nuget.newtonsoft-json": "3.2.1",
@@ -173,12 +173,29 @@
     },
     "com.unity.services.core": {
       "version": "1.11.0",
-      "depth": 2,
+      "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.unity.modules.unitywebrequest": "1.0.0",
         "com.unity.nuget.newtonsoft-json": "3.2.1",
         "com.unity.modules.androidjni": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.services.lobby": {
+      "version": "1.1.0",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.services.core": "1.8.2",
+        "com.unity.modules.unitywebrequest": "1.0.0",
+        "com.unity.modules.unitywebrequestassetbundle": "1.0.0",
+        "com.unity.modules.unitywebrequestaudio": "1.0.0",
+        "com.unity.modules.unitywebrequesttexture": "1.0.0",
+        "com.unity.modules.unitywebrequestwww": "1.0.0",
+        "com.unity.nuget.newtonsoft-json": "3.0.2",
+        "com.unity.services.authentication": "2.1.1",
+        "com.unity.services.wire": "1.1.8"
       },
       "url": "https://packages.unity.com"
     },
@@ -210,6 +227,17 @@
         "com.unity.modules.unitywebrequestwww": "1.0.0",
         "com.unity.nuget.newtonsoft-json": "3.0.2",
         "com.unity.transport": "1.3.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.services.wire": {
+      "version": "1.2.0",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.services.core": "1.10.1",
+        "com.unity.nuget.newtonsoft-json": "3.2.1",
+        "com.unity.services.authentication": "2.6.1"
       },
       "url": "https://packages.unity.com"
     },

--- a/ProjectSettings/Packages/com.unity.services.core/Settings.json
+++ b/ProjectSettings/Packages/com.unity.services.core/Settings.json
@@ -1,0 +1,1 @@
+{"EnvironmentName":""}

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -3,12 +3,13 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 2
-  tags: []
+  tags:
+  - Trap
   layers:
   - Default
   - TransparentFX
   - Ignore Raycast
-  - 
+  - HideFromThief
   - Water
   - UI
   - 


### PR DESCRIPTION
- Multiplayer will now function across any network, not just LAN
- Hosts will now create a basic lobby with a room code, clients can use that code to join their game
- Thief/guard selection is now independent of host/client status (should be easier to test thief puzzles now)
- Added player spawn point, so additional thieves don't fall through the map anymore
- Tiles are now only visible through guard cameras, not in thief view

SIDE NOTE: ParrelSync does not work with Unity's Relay server as of now, so testing two players on one machine is currently not possible. (The Relay server has heavy rate limits and will get mad if it sees the same Unity ID on their server twice) I'll look into a fix for this, but for now you will need multiple machines to test this PR properly. If you're not able to do that, message me and I'll be happy to help you test stuff.