### PR TITLE
Monitor fixes

### DIFF
--- a/Assets/Scripts/Security/AttachCamera.cs
+++ b/Assets/Scripts/Security/AttachCamera.cs
@@ -28,4 +28,9 @@ public class AttachCamera : MonoBehaviour
         attachedCamera = newCamera;
         newCamera.targetTexture = texture;
     }
+
+    public ControllableCamera GetControllableCamera()
+    {
+        return attachedCamera.GetComponent<ControllableCamera>();
+    }
 }

--- a/Assets/Scripts/Security/AttachCamera.cs
+++ b/Assets/Scripts/Security/AttachCamera.cs
@@ -16,6 +16,7 @@ public class AttachCamera : MonoBehaviour
         RenderTexture texture = new RenderTexture(256, 256, 0);
         monitor.GetComponent<MeshRenderer>().materials[0].SetTexture("_MainTex", texture);
         attachedCamera.targetTexture = texture;
+        attachedCamera.enabled = true;
     }
 
     public Camera GetAttachedCamera() { return attachedCamera; }

--- a/Assets/Scripts/Security/AttachCamera.cs
+++ b/Assets/Scripts/Security/AttachCamera.cs
@@ -23,7 +23,6 @@ public class AttachCamera : MonoBehaviour
 
     public void SetAttachedCamera(Camera newCamera)
     {
-        Debug.Log(newCamera.name);
         attachedCamera.targetTexture = null;
         attachedCamera = newCamera;
         newCamera.targetTexture = texture;

--- a/Assets/Scripts/Security/AttachCamera.cs
+++ b/Assets/Scripts/Security/AttachCamera.cs
@@ -13,7 +13,7 @@ public class AttachCamera : MonoBehaviour
     {
         monitor = transform.GetChild(0).gameObject;
 
-        RenderTexture texture = new RenderTexture(256, 256, 0);
+        texture = new RenderTexture(256, 256, 0);
         monitor.GetComponent<MeshRenderer>().materials[0].SetTexture("_MainTex", texture);
         attachedCamera.targetTexture = texture;
         attachedCamera.enabled = true;

--- a/Assets/Scripts/Security/AttachCamera.cs
+++ b/Assets/Scripts/Security/AttachCamera.cs
@@ -22,6 +22,7 @@ public class AttachCamera : MonoBehaviour
 
     public void SetAttachedCamera(Camera newCamera)
     {
+        Debug.Log(newCamera.name);
         attachedCamera.targetTexture = null;
         attachedCamera = newCamera;
         newCamera.targetTexture = texture;

--- a/Assets/Scripts/Security/AttachCamera.cs
+++ b/Assets/Scripts/Security/AttachCamera.cs
@@ -7,6 +7,8 @@ public class AttachCamera : MonoBehaviour
     [SerializeField] private Camera attachedCamera;
     private GameObject monitor;
 
+    private RenderTexture texture;
+
     private void Start()
     {
         monitor = transform.GetChild(0).gameObject;
@@ -17,4 +19,11 @@ public class AttachCamera : MonoBehaviour
     }
 
     public Camera GetAttachedCamera() { return attachedCamera; }
+
+    public void SetAttachedCamera(Camera newCamera)
+    {
+        attachedCamera.targetTexture = null;
+        attachedCamera = newCamera;
+        newCamera.targetTexture = texture;
+    }
 }

--- a/Assets/Scripts/Security/CameraViewer.cs
+++ b/Assets/Scripts/Security/CameraViewer.cs
@@ -98,6 +98,7 @@ public class CameraViewer : Singleton<CameraViewer>
         cameraUI.SetActive(true);
         mainCamera.enabled = false;
 
+        attachCamera = monitor;
         currentCamera = camera;
         currentCameraGroup = camera.GetCameraGroup();
         currentCameraIndex = camera.GetCameraGroupIndex();

--- a/Assets/Scripts/Security/CameraViewer.cs
+++ b/Assets/Scripts/Security/CameraViewer.cs
@@ -18,6 +18,7 @@ public class CameraViewer : Singleton<CameraViewer>
     private ControllableCamera currentCamera;
     private int currentCameraIndex;
     private AudioSource audioSource;
+    private AttachCamera attachCamera;
 
     private void Start()
     {
@@ -89,7 +90,7 @@ public class CameraViewer : Singleton<CameraViewer>
         }*/
     }
 
-    public void ViewCamera(ControllableCamera camera)
+    public void ViewCamera(ControllableCamera camera, AttachCamera monitor)
     {
         Cursor.lockState = CursorLockMode.None;
         

--- a/Assets/Scripts/Security/CameraViewer.cs
+++ b/Assets/Scripts/Security/CameraViewer.cs
@@ -115,6 +115,8 @@ public class CameraViewer : Singleton<CameraViewer>
         currentCamera.ExitView();
         cameraUI.SetActive(false);
         mainCamera.enabled = true;
+
+        attachCamera.SetAttachedCamera(currentCamera.GetCamera());
         
         currentCamera = null;
         currentCameraGroup = null;

--- a/Assets/Scripts/Security/ControllableCamera.cs
+++ b/Assets/Scripts/Security/ControllableCamera.cs
@@ -48,9 +48,10 @@ public class ControllableCamera : MonoBehaviour
 
     private void Update()
     {
-        if (camera.targetTexture is null && !viewing)
+        if (camera.enabled && camera.targetTexture is null && !viewing)
         {
             camera.enabled = false;
+            Debug.Log("Disabling camera.");
         }
 
         audioListener.enabled = viewing;

--- a/Assets/Scripts/Security/ControllableCamera.cs
+++ b/Assets/Scripts/Security/ControllableCamera.cs
@@ -53,7 +53,6 @@ public class ControllableCamera : MonoBehaviour
         if (camera.enabled && camera.targetTexture is null && !viewing)
         {
             camera.enabled = false;
-            Debug.Log("Disabling camera.");
         }
 
         audioListener.enabled = viewing;
@@ -128,6 +127,7 @@ public class ControllableCamera : MonoBehaviour
 
     public void EnterView()
     {
+        if (camera.targetTexture == null) { Debug.Log("Entered " + camera.name + " but had no texture!"); }
         camera.targetTexture = null;
         camera.enabled = true;
         viewing = true;

--- a/Assets/Scripts/Security/ControllableCamera.cs
+++ b/Assets/Scripts/Security/ControllableCamera.cs
@@ -42,8 +42,7 @@ public class ControllableCamera : MonoBehaviour
         rotX = transform.localRotation.eulerAngles.x;
         rotY = transform.localRotation.eulerAngles.y;
 
-        Debug.Log(transform.localPosition);
-        Debug.Log(transform.position);
+        
     }
 
     private void Update()

--- a/Assets/Scripts/Security/ControllableCamera.cs
+++ b/Assets/Scripts/Security/ControllableCamera.cs
@@ -52,6 +52,7 @@ public class ControllableCamera : MonoBehaviour
     {
         if (camera.enabled && camera.targetTexture is null && !viewing)
         {
+            Debug.Log("Disabling " + camera.name);
             camera.enabled = false;
         }
 
@@ -127,7 +128,6 @@ public class ControllableCamera : MonoBehaviour
 
     public void EnterView()
     {
-        if (camera.targetTexture == null) { Debug.Log("Entered " + camera.name + " but had no texture!"); }
         camera.targetTexture = null;
         camera.enabled = true;
         viewing = true;

--- a/Assets/Scripts/Security/ControllableCamera.cs
+++ b/Assets/Scripts/Security/ControllableCamera.cs
@@ -52,7 +52,6 @@ public class ControllableCamera : MonoBehaviour
     {
         if (camera.enabled && camera.targetTexture is null && !viewing)
         {
-            Debug.Log("Disabling " + camera.name);
             camera.enabled = false;
         }
 

--- a/Assets/Scripts/Security/ControllableCamera.cs
+++ b/Assets/Scripts/Security/ControllableCamera.cs
@@ -42,7 +42,10 @@ public class ControllableCamera : MonoBehaviour
         rotX = transform.localRotation.eulerAngles.x;
         rotY = transform.localRotation.eulerAngles.y;
 
-        
+        if (camera.targetTexture is null)
+        {
+            camera.enabled = false;
+        }
     }
 
     private void Update()

--- a/Assets/Scripts/Security/SelectMonitor.cs
+++ b/Assets/Scripts/Security/SelectMonitor.cs
@@ -9,14 +9,14 @@ public class SelectMonitor : MonoBehaviour
     [SerializeField] private Material selectedMaterial;
 
     private GameObject containerCube;
-    private ControllableCamera camera;
+    private ControllableCamera controllableCamera;
     private AttachCamera attachCamera;
 
     private void Start()
     {
         containerCube = transform.Find("ContainerCube").gameObject;
         attachCamera = GetComponent<AttachCamera>();
-        camera = attachCamera.GetAttachedCamera().GetComponent<ControllableCamera>();
+        controllableCamera = attachCamera.GetAttachedCamera().GetComponent<ControllableCamera>();
     }
 
     private void OnMouseEnter()
@@ -45,6 +45,6 @@ public class SelectMonitor : MonoBehaviour
             return;
         }
 
-        CameraViewer.Instance.ViewCamera(camera, attachCamera);
+        CameraViewer.Instance.ViewCamera(controllableCamera, attachCamera);
     }
 }

--- a/Assets/Scripts/Security/SelectMonitor.cs
+++ b/Assets/Scripts/Security/SelectMonitor.cs
@@ -9,14 +9,12 @@ public class SelectMonitor : MonoBehaviour
     [SerializeField] private Material selectedMaterial;
 
     private GameObject containerCube;
-    private ControllableCamera controllableCamera;
     private AttachCamera attachCamera;
 
     private void Start()
     {
         containerCube = transform.Find("ContainerCube").gameObject;
         attachCamera = GetComponent<AttachCamera>();
-        controllableCamera = attachCamera.GetAttachedCamera().GetComponent<ControllableCamera>();
     }
 
     private void OnMouseEnter()
@@ -45,6 +43,6 @@ public class SelectMonitor : MonoBehaviour
             return;
         }
 
-        CameraViewer.Instance.ViewCamera(controllableCamera, attachCamera);
+        CameraViewer.Instance.ViewCamera(attachCamera.GetControllableCamera(), attachCamera);
     }
 }

--- a/Assets/Scripts/Security/SelectMonitor.cs
+++ b/Assets/Scripts/Security/SelectMonitor.cs
@@ -9,12 +9,14 @@ public class SelectMonitor : MonoBehaviour
     [SerializeField] private Material selectedMaterial;
 
     private GameObject containerCube;
-    private ControllableCamera attachedCamera;
+    private ControllableCamera camera;
+    private AttachCamera attachCamera;
 
     private void Start()
     {
         containerCube = transform.Find("ContainerCube").gameObject;
-        attachedCamera = GetComponent<AttachCamera>().GetAttachedCamera().GetComponent<ControllableCamera>();
+        attachCamera = GetComponent<AttachCamera>();
+        camera = attachCamera.GetAttachedCamera().GetComponent<ControllableCamera>();
     }
 
     private void OnMouseEnter()
@@ -43,6 +45,6 @@ public class SelectMonitor : MonoBehaviour
             return;
         }
 
-        CameraViewer.Instance.ViewCamera(attachedCamera);
+        CameraViewer.Instance.ViewCamera(camera, attachCamera);
     }
 }


### PR DESCRIPTION
Monitors should now remain unpaused when you enter and leave, and if you switch cameras, that should reflect in the monitor and when you zoom back in.