### PR TITLE
Quick fixes

### DIFF
--- a/Assets/Prefabs/Players/Thief.prefab
+++ b/Assets/Prefabs/Players/Thief.prefab
@@ -672,7 +672,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   treasureCount: 0
-  goal: 8
+  goal: 6
 --- !u!114 &503376195182715850
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Rooms/FishEyeCamera.prefab
+++ b/Assets/Prefabs/Rooms/FishEyeCamera.prefab
@@ -85,9 +85,25 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 2589072669745163451}
     m_Modifications:
+    - target: {fileID: 481357583326168729, guid: b91a409196749b34f88f70cf386c9f7d, type: 3}
+      propertyPath: rotMaxX
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 481357583326168729, guid: b91a409196749b34f88f70cf386c9f7d, type: 3}
+      propertyPath: rotMaxY
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 481357583326168729, guid: b91a409196749b34f88f70cf386c9f7d, type: 3}
+      propertyPath: rotMinX
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4900169476381128665, guid: b91a409196749b34f88f70cf386c9f7d, type: 3}
       propertyPath: m_Name
       value: Camera
+      objectReference: {fileID: 0}
+    - target: {fileID: 6113658307437034838, guid: b91a409196749b34f88f70cf386c9f7d, type: 3}
+      propertyPath: field of view
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 7712274910360272697, guid: b91a409196749b34f88f70cf386c9f7d, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Prefabs/Rooms/PlatformRoom/Storage Room B.prefab
+++ b/Assets/Prefabs/Rooms/PlatformRoom/Storage Room B.prefab
@@ -133,8 +133,7 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 9019283608623785796}
+  m_Children: []
   m_Father: {fileID: 2847222461270930011}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1934832198925130473
@@ -2753,76 +2752,6 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 1716421496538252777, guid: 6272e36fa619a6f4ba7d8daf92d6bb80, type: 3}
   m_PrefabInstance: {fileID: 8749142948518094071}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &8836159065302974639
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 8927936526396014701}
-    m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 0.010000001
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 5.660001
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.17070413
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 2.2163658
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.67145824
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.65294963
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.2512292
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.24430417
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -88.399
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -41.027
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -7511558181221131132, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 3ed669ef9a93fc841b27ab87a3653284, type: 2}
-    - target: {fileID: 919132149155446097, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
-      propertyPath: m_Name
-      value: Katana_Relic_UV
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
---- !u!4 &9019283608623785796 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
-  m_PrefabInstance: {fileID: 8836159065302974639}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &9102792947258953456
 PrefabInstance:

--- a/Assets/Prefabs/Rooms/PlatformRoom/StorageRoomA.prefab
+++ b/Assets/Prefabs/Rooms/PlatformRoom/StorageRoomA.prefab
@@ -180,8 +180,7 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 9108413883191731161}
+  m_Children: []
   m_Father: {fileID: 6261284614492023444}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2984934034080998858
@@ -3916,72 +3915,6 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 3763316573350028480, guid: 177a2eadebf29eb4c812173643e2931e, type: 3}
   m_PrefabInstance: {fileID: 8608963547375556349}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &8785730496234275890
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 7535333984353959132}
-    m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.42000198
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.94970393
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 5.6116333
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0.9229773
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0.3848543
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -45.269
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -7511558181221131132, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 3ed669ef9a93fc841b27ab87a3653284, type: 2}
-    - target: {fileID: 919132149155446097, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
-      propertyPath: m_Name
-      value: Katana_Relic_UV
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
---- !u!4 &9108413883191731161 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
-  m_PrefabInstance: {fileID: 8785730496234275890}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8829174222192094529
 PrefabInstance:

--- a/Assets/Prefabs/Rooms/Relic.prefab
+++ b/Assets/Prefabs/Rooms/Relic.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 717447500279575401}
   - component: {fileID: 4749066385410182541}
   - component: {fileID: 5151294396070596322}
+  - component: {fileID: 7897162738564184053}
   m_Layer: 0
   m_Name: Relic
   m_TagString: Treasure
@@ -168,6 +169,18 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+--- !u!114 &7897162738564184053
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2864547810284871222}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d1f4af8e6142d9498c341eba7f48faa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &8193989630950816611
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Rooms/Relic.prefab
+++ b/Assets/Prefabs/Rooms/Relic.prefab
@@ -33,6 +33,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 682933793672801672}
+  - {fileID: 1387026899673902137}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!136 &717447500279575401
@@ -179,7 +180,7 @@ GameObject:
   - component: {fileID: 485100607490038393}
   - component: {fileID: 8521167283954299218}
   m_Layer: 0
-  m_Name: Model
+  m_Name: Tusk
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -250,3 +251,69 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1001 &1492113010679090130
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5850475496155396086}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.000000020529368
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.2079027
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.6
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.67014396
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.22562602
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.67014396
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.22562602
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -37.215
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 3ed669ef9a93fc841b27ab87a3653284, type: 2}
+    - target: {fileID: 919132149155446097, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
+      propertyPath: m_Name
+      value: Katana
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
+--- !u!4 &1387026899673902137 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: ff45212f606781448ae5c1d32cfaa51c, type: 3}
+  m_PrefabInstance: {fileID: 1492113010679090130}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/Rooms/RelicOnStand.prefab
+++ b/Assets/Prefabs/Rooms/RelicOnStand.prefab
@@ -101,6 +101,42 @@ PrefabInstance:
       propertyPath: m_Center.z
       value: 0.030823708
       objectReference: {fileID: 0}
+    - target: {fileID: 1387026899673902137, guid: bc1053ec46c5a194889b16b24cf7df80, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.9000001
+      objectReference: {fileID: 0}
+    - target: {fileID: 1387026899673902137, guid: bc1053ec46c5a194889b16b24cf7df80, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 1387026899673902137, guid: bc1053ec46c5a194889b16b24cf7df80, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.19999982
+      objectReference: {fileID: 0}
+    - target: {fileID: 1387026899673902137, guid: bc1053ec46c5a194889b16b24cf7df80, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1387026899673902137, guid: bc1053ec46c5a194889b16b24cf7df80, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1387026899673902137, guid: bc1053ec46c5a194889b16b24cf7df80, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1387026899673902137, guid: bc1053ec46c5a194889b16b24cf7df80, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1387026899673902137, guid: bc1053ec46c5a194889b16b24cf7df80, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: 1387026899673902137, guid: bc1053ec46c5a194889b16b24cf7df80, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -90
+      objectReference: {fileID: 0}
     - target: {fileID: 2864547810284871222, guid: bc1053ec46c5a194889b16b24cf7df80, type: 3}
       propertyPath: m_Name
       value: Relic
@@ -156,6 +192,10 @@ PrefabInstance:
     - target: {fileID: 5850475496155396086, guid: bc1053ec46c5a194889b16b24cf7df80, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8193989630950816611, guid: bc1053ec46c5a194889b16b24cf7df80, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scripts/Items/RelicPickup.cs
+++ b/Assets/Scripts/Items/RelicPickup.cs
@@ -15,7 +15,10 @@ public class RelicPickup : MonoBehaviour
             inv.treasureCount += Value;
             ScoreTracker.Instance.treasureValue++;
             GetComponent<CapsuleCollider>().enabled = false;
-            Destroy(transform.GetChild(0).gameObject);
+            foreach (Transform child in transform)
+            {
+                Destroy(child.gameObject);
+            }
             GetComponent<AudioSource>().Play();
 
             if (inv.treasureCount >= inv.goal)

--- a/Assets/Scripts/Items/RepairPickup.cs
+++ b/Assets/Scripts/Items/RepairPickup.cs
@@ -9,8 +9,11 @@ public class RepairPickup : MonoBehaviour
         ThiefManager thief = other.gameObject.GetComponent<ThiefManager>();
         if (thief != null)
         {
-            thief.Repair();
-            Destroy(gameObject);
+            if (thief.needsRepair)
+            {
+                thief.Repair();
+                Destroy(gameObject);
+            }
         }
     }
 }

--- a/Assets/Scripts/Rooms/SecurityDoor.cs
+++ b/Assets/Scripts/Rooms/SecurityDoor.cs
@@ -11,13 +11,7 @@ public class SecurityDoor : MonoBehaviour
         ThiefManager thief = other.gameObject.GetComponent<ThiefManager>();
         if (thief != null)
         {
-            // Try winning before repairing. No need to repair if you won.
-            if (!thief.AttemptWin())
-            {
-                if (thief.needsRepair && thief.repairsRemaining > 0) { 
-                    thief.Repair();
-                }
-            }
+            thief.AttemptWin();
         }
     }
 }


### PR DESCRIPTION
- Relics can now be katanas
- Security door no longer repairs
- Goal reduced to 6 relics
- Repair kit ignored if already in good repair
- Fisheye cameras have higher FOV and no rotation