### PR TITLE
Room-based dialogue will trigger on camera view, not room entry

### DIFF
--- a/Assets/Scripts/Audio/Dialogue/DialogueManager.cs
+++ b/Assets/Scripts/Audio/Dialogue/DialogueManager.cs
@@ -71,6 +71,9 @@ public class DialogueManager : Singleton<DialogueManager>
 
         dialogueToPlay.Play(audioSource);
         currentDialogue = dialogueToPlay;
+
+        //Uncomment this if you need to test dialogue events but cannot listen to the result because you are in class
+        //Debug.Log($"Now playing {dialogueEvent}...");
     }
 
     private DialogueObject getDialogueObjectByEvent(DialogueEvent dialogueEvent)

--- a/Assets/Scripts/Environment/PositionTrackers/RoomTracker.cs
+++ b/Assets/Scripts/Environment/PositionTrackers/RoomTracker.cs
@@ -9,20 +9,6 @@ public class RoomTracker : MonoBehaviour
     [SerializeField] private int roomIndex = -1;
 
     private TileRoomRandomizer tileRoomRandomizer;
-    private bool isTileRoom = false;
-    private bool isShockTileRoom = false;
-    private bool isGuardTileRoom = false;
-    
-    private void Start()
-    {
-        tileRoomRandomizer = transform.parent.GetComponentInChildren<TileRoomRandomizer>();
-        if (tileRoomRandomizer is not null)
-        {
-            isTileRoom = true;
-            isShockTileRoom = tileRoomRandomizer.trapsDamage;
-            isGuardTileRoom = tileRoomRandomizer.trapsAlertGuard;
-        }
-    }
 
     private void OnTriggerEnter(Collider other)
     {
@@ -30,26 +16,9 @@ public class RoomTracker : MonoBehaviour
         {
             Minimap.Instance.UpdatePlayerRoomLocation(roomIndex);
 
-            if (isTileRoom)
-            {
-                if (isShockTileRoom)
-                {
-                    DialogueManager.Instance.PlayDialogue(DialogueEvent.ENTER_TILE_ROOM_SHOCK);
-                }
-                else if (isGuardTileRoom)
-                {
-                    DialogueManager.Instance.PlayDialogue(DialogueEvent.ENTER_TILE_ROOM_GUARD);
-                }
-            }
-
-            else if (roomIndex == 0)
+            if (roomIndex == 0)
             {
                 DialogueManager.Instance.PlayDialogue(DialogueEvent.GAME_START);
-            }
-
-            else
-            {
-                DialogueManager.Instance.PlayDialogue(DialogueEvent.PLATFORMER_ROOM);
             }
         }
     }

--- a/Assets/Scripts/Environment/Security/Cameras/CameraViewer.cs
+++ b/Assets/Scripts/Environment/Security/Cameras/CameraViewer.cs
@@ -113,10 +113,31 @@ public class CameraViewer : Singleton<CameraViewer>
 
         SwapCamera(currentCameraIndex);
 
-        if (camera.IsFishEye())
+        //TODO: These checks are hacky and shitty and will probably change for the better once we have full difficulty-based randomization for rooms
+        GameObject viewingRoom = currentCamera.transform.parent.parent.gameObject;
+        bool viewingTileRoom = viewingRoom.GetComponentInChildren<TileRoomRandomizer>() is not null;
+        bool viewingPlatformRoom = viewingRoom.GetComponentInChildren<FixedTrapManager>() is not null;
+
+        if (viewingTileRoom)
         {
-            DialogueManager.Instance.PlayDialogue(DialogueEvent.VIEW_MONITOR_FISH_EYE);
+            bool shockTileRoom = viewingRoom.GetComponentInChildren<TileRoomRandomizer>().trapsDamage;
+            bool guardTileRoom = viewingRoom.GetComponentInChildren<TileRoomRandomizer>().trapsAlertGuard;
+
+            if (shockTileRoom)
+            {
+                DialogueManager.Instance.PlayDialogue(DialogueEvent.ENTER_TILE_ROOM_SHOCK);
+            }
+            else if (guardTileRoom)
+            {
+                DialogueManager.Instance.PlayDialogue(DialogueEvent.ENTER_TILE_ROOM_GUARD);
+            }
         }
+
+        else if (viewingPlatformRoom)
+        {
+            DialogueManager.Instance.PlayDialogue(DialogueEvent.PLATFORMER_ROOM);
+        }
+
         else
         {
             DialogueManager.Instance.PlayDialogue(DialogueEvent.VIEW_MONITOR);


### PR DESCRIPTION
- Viewing a tile room will play the dialogue for that respective tile room type.
- Viewing a platform room will play the dialogue for that platform room.
- Viewing a hallway will play the default camera viewing dialogue ("it looks like there are two guards on shift...")

I'd also like to make a note to come back and redo how these triggers are done once difficulty-based room randomization is fully in place, cus right now this implementation is very messy and having more organized room generation will hopefully make this less ugly. But for now, this should work.